### PR TITLE
Fixes for Linux / macOS

### DIFF
--- a/BIN/_app/README.md
+++ b/BIN/_app/README.md
@@ -1,0 +1,14 @@
+# _app
+
+Special Env Vars:
+
+- `OEL_RPCS3_DIR`: RPCS3 installation path (if not streamlined install)
+- `OEL_RPCS3_SYSTEM`: Use system wide RPCS3 data path (if not portable)
+- `OEL_RPCS3_DATA_DIR`: RPCS3 data path (if not portable)
+- `OEL_RPCN_DIR`: RPCN installation path (if not streamlined install)
+- `OEL_RPCN_DATA_DIR`: RPCN data path (if not portable)
+- `OEL_LOG_DIR`: path to log directory
+- `ACI_BIND_IP`: IP to bind to
+- `ACI_HTTP_PORT`: HTTP port to bind to
+- `ACI_HTTPS_PORT`: HTTPS port to bind to
+

--- a/BIN/_app/gameserver/gameserver.sh
+++ b/BIN/_app/gameserver/gameserver.sh
@@ -4,4 +4,4 @@ cd $(dirname "$0")
 
 BIND_IP="${1:-"0.0.0.0"}"
 
-/usr/bin/env python3 opeternal_listener.py --bind-ip "%BIND_IP%"
+/usr/bin/env python3 opeternal_listener.py --bind-ip "${BIND_IP}"

--- a/BIN/_app/gameserver/gameserver.sh
+++ b/BIN/_app/gameserver/gameserver.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cd $(dirname "$0")
+
+BIND_IP="${1:-"0.0.0.0"}"
+
+/usr/bin/env python3 opeternal_listener.py --bind-ip "%BIND_IP%"

--- a/BIN/_app/launcher.py
+++ b/BIN/_app/launcher.py
@@ -32,9 +32,9 @@ PLATFORM = platform.system()
 # ---------------------------------------------------------------------------
 APP_DIR     = Path(__file__).parent.resolve()   # _app/
 ROOT_DIR    = APP_DIR.parent                    # folder user sees (where TSS/ lives)
-RPCS3_DIR   = os.getenv("OEL_RPCS3_DIR") or APP_DIR / "RPCS3"
-RPCN_DIR    = os.getenv("OEL_RPCN_DIR") or APP_DIR / "rpcn"
-RPCN_DATA_DIR = os.getenv("OEL_RPCN_DATA_DIR") or RPCN_DIR
+RPCS3_DIR   = Path(os.getenv("OEL_RPCS3_DIR") or (APP_DIR / "RPCS3"))
+RPCN_DIR    = Path(os.getenv("OEL_RPCN_DIR") or (APP_DIR / "rpcn"))
+RPCN_DATA_DIR = Path(os.getenv("OEL_RPCN_DATA_DIR") or RPCN_DIR)
 GAMESERVER_DIR = APP_DIR / "gameserver"
 PATCHES_DIR = APP_DIR / "patches"
 
@@ -54,11 +54,15 @@ else:
 
 GAMESERVER_SCRIPT = GAMESERVER_DIR / "opeternal_listener.py"
 
-if not os.getenv("OEL_RPCS3_SYSTEM"):
-    RPCS3_DATA_DIR = os.getenv("OEL_RPCS3_DATA_DIR") or RPCS3_DIR / "portable"
+if "OEL_RPCS3_SYSTEM" not in os.environ:
+    RPCS3_DATA_DIR = Path(os.getenv("OEL_RPCS3_DATA_DIR") or (RPCS3_DIR / "portable"))
 
-RPCN_YML    = RPCS3_DATA_DIR / "config" / "rpcn.yml"
-CUSTOM_CFG  = RPCS3_DATA_DIR / "config" / "custom_configs" / "config_NPUB31347.yml"
+RPCS3_CONFIG_DIR = RPCS3_DATA_DIR
+if PLATFORM == 'Windows':
+    RPCS3_CONFIG_DIR = RPCS3_CONFIG_DIR / "config"
+
+RPCN_YML    = RPCS3_CONFIG_DIR / "rpcn.yml"
+CUSTOM_CFG  = RPCS3_CONFIG_DIR / "custom_configs" / "config_NPUB31347.yml"
 TSS_SRC_DIR = ROOT_DIR / "TSS"
 RPCS3_TSS   = RPCS3_DATA_DIR / "tss"
 RPCN_TSS    = RPCN_DATA_DIR / "tss_data" / "NPWR04428_00"
@@ -153,12 +157,14 @@ class LaunchWorker(QThread):
             self.log.emit(f"TSS: {n}/15 files copied.")
 
             self.log.emit("Deploying patches...")
-            cfg_mod.deploy_patches(str(RPCS3_DIR), str(PATCHES_DIR))
-            cfg_mod.install_gui_assets(str(RPCS3_DIR), str(PATCHES_DIR))
+            cfg_mod.deploy_patches(str(RPCS3_DATA_DIR), str(RPCS3_CONFIG_DIR), str(PATCHES_DIR))
+            cfg_mod.install_gui_assets(str(RPCS3_DATA_DIR), str(PATCHES_DIR))
 
             self.log.emit("Configuring RPCS3...")
             ok = cfg_mod.ensure_custom_config(
-                str(RPCS3_DIR), str(RPCS3_EXE),
+                str(RPCS3_DATA_DIR), 
+                str(RPCS3_CONFIG_DIR),
+                str(RPCS3_EXE),
                 progress_cb=lambda m: self.log.emit(m),
             )
             if not ok:
@@ -1088,7 +1094,7 @@ class ACILauncher(QMainWindow):
             if not self._restore_staged:
                 tus_saves.cleanup_restore_sentinels(str(RPCS3_DATA_DIR / "tus"))
             self._restore_staged = False
-            self._rpcs3_proc.launch(str(RPCS3_EXE), [], cwd=str(RPCS3_DIR))
+            self._rpcs3_proc.launch(str(RPCS3_EXE), [], cwd=str(RPCS3_DATA_DIR))
 
         self._play_tab.set_launch_enabled(True)
         self._tss_tab.refresh()

--- a/BIN/_app/launcher.py
+++ b/BIN/_app/launcher.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """OP ETERNAL Launcher - OPERATION ETERNAL LIBERATION."""
 import glob
 import json
@@ -5,6 +6,8 @@ import os
 import shutil
 import sys
 import time
+import pathlib
+import platform
 from pathlib import Path
 
 from PySide6.QtCore import (
@@ -22,33 +25,51 @@ from PySide6.QtWidgets import (
     QSpinBox, QFrame, QSizePolicy, QButtonGroup, QScrollArea,
 )
 
+PLATFORM = platform.system()
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 APP_DIR     = Path(__file__).parent.resolve()   # _app/
 ROOT_DIR    = APP_DIR.parent                    # folder user sees (where TSS/ lives)
-RPCS3_DIR   = APP_DIR / "RPCS3"
-RPCN_DIR    = APP_DIR / "rpcn"
+RPCS3_DIR   = os.getenv("OEL_RPCS3_DIR") or APP_DIR / "RPCS3"
+RPCN_DIR    = os.getenv("OEL_RPCN_DIR") or APP_DIR / "rpcn"
+RPCN_DATA_DIR = os.getenv("OEL_RPCN_DATA_DIR") or RPCN_DIR
 GAMESERVER_DIR = APP_DIR / "gameserver"
 PATCHES_DIR = APP_DIR / "patches"
-PYTHON_EXE  = APP_DIR / "python" / "python.exe"
-RPCS3_EXE   = RPCS3_DIR / "rpcs3.exe"
-RPCN_EXE    = RPCN_DIR / "rpcn.exe"
+
+PYTHON_EXE  = sys.executable
+if PLATFORM == 'Windows':
+    RPCS3_EXE = RPCS3_DIR / "rpcs3.exe"
+    RPCN_EXE  = RPCN_DIR / "rpcn.exe"
+    RPCS3_DATA_DIR = Path(os.getenv('APPDATA')) / 'RPCS3'
+elif PLATFORM == 'Darwin':
+    RPCS3_EXE = RPCS3_DIR
+    RPCN_EXE  = RPCN_DIR / "rpcn"
+    RPCS3_DATA_DIR = Path(os.getenv('HOME')) / 'Library' / 'Application Support' / 'rpcs3'
+else:
+    RPCS3_EXE = RPCS3_DIR / "rpcs3"
+    RPCN_EXE  = RPCN_DIR / "rpcn"
+    RPCS3_DATA_DIR = Path(os.getenv('HOME')) / '.config' / 'rpcs3'
+
 GAMESERVER_SCRIPT = GAMESERVER_DIR / "opeternal_listener.py"
-PORTABLE_DIR = RPCS3_DIR / "portable"
-RPCN_YML    = PORTABLE_DIR / "config" / "rpcn.yml"
-CUSTOM_CFG  = PORTABLE_DIR / "config" / "custom_configs" / "config_NPUB31347.yml"
+
+if not os.getenv("OEL_RPCS3_SYSTEM"):
+    RPCS3_DATA_DIR = os.getenv("OEL_RPCS3_DATA_DIR") or RPCS3_DIR / "portable"
+
+RPCN_YML    = RPCS3_DATA_DIR / "config" / "rpcn.yml"
+CUSTOM_CFG  = RPCS3_DATA_DIR / "config" / "custom_configs" / "config_NPUB31347.yml"
 TSS_SRC_DIR = ROOT_DIR / "TSS"
-RPCS3_TSS   = PORTABLE_DIR / "tss"
-RPCN_TSS    = RPCN_DIR / "tss_data" / "NPWR04428_00"
+RPCS3_TSS   = RPCS3_DATA_DIR / "tss"
+RPCN_TSS    = RPCN_DATA_DIR / "tss_data" / "NPWR04428_00"
 SETTINGS_FILE = APP_DIR / "settings.json"
 
 VERSION = "1.0.2"
 
 COMMUNITY_RPCN_HOST = "np.rpcs3.net"
 
-FIRMWARE_INDICATOR = PORTABLE_DIR / "dev_flash" / "sys" / "external" / "libsre.sprx"
-GAME_INDICATOR     = PORTABLE_DIR / "dev_hdd0"  / "game"             / "NPUB31347" / "PARAM.SFO"
+FIRMWARE_INDICATOR = RPCS3_DATA_DIR / "dev_flash" / "sys" / "external" / "libsre.sprx"
+GAME_INDICATOR     = RPCS3_DATA_DIR / "dev_hdd0"  / "game"             / "NPUB31347" / "PARAM.SFO"
 
 # Modules live next to this file
 sys.path.insert(0, str(APP_DIR))
@@ -525,7 +546,7 @@ class SaveEditorTab(QWidget):
         self._write_btn.clicked.connect(self._write_saves)
 
     def _auto_detect_saves(self):
-        pattern = str(PORTABLE_DIR / "tus" / "NPWR04428_00" / "*")
+        pattern = str(RPCS3_DATA_DIR / "tus" / "NPWR04428_00" / "*")
         matches = glob.glob(pattern)
         if matches:
             self._save_dir = matches[0]
@@ -659,7 +680,7 @@ class BackupRestoreTab(QWidget):
         self._refresh()
 
     def _tus_root(self) -> str:
-        return str(PORTABLE_DIR / "tus")
+        return str(RPCS3_DATA_DIR / "tus")
 
     def _refresh(self):
         tus_root = self._tus_root()
@@ -1060,12 +1081,12 @@ class ACILauncher(QMainWindow):
 
         if rpcn_mode == "self_hosted" and not self._rpcn_proc.is_running():
             QTimer.singleShot(2000, lambda: self._rpcn_proc.launch(
-                str(RPCN_EXE), [], cwd=str(RPCN_DIR), new_console=True,
+                str(RPCN_EXE), [], cwd=str(RPCN_DATA_DIR), new_console=True,
             ))
 
         if not self._rpcs3_proc.is_running():
             if not self._restore_staged:
-                tus_saves.cleanup_restore_sentinels(str(PORTABLE_DIR / "tus"))
+                tus_saves.cleanup_restore_sentinels(str(RPCS3_DATA_DIR / "tus"))
             self._restore_staged = False
             self._rpcs3_proc.launch(str(RPCS3_EXE), [], cwd=str(RPCS3_DIR))
 
@@ -1074,7 +1095,7 @@ class ACILauncher(QMainWindow):
 
     def _on_rpcs3_stopped(self, _exit_code: int):
         self._play_tab.refresh_setup_status()
-        tus_saves.cleanup_restore_sentinels(str(PORTABLE_DIR / "tus"))
+        tus_saves.cleanup_restore_sentinels(str(RPCS3_DATA_DIR / "tus"))
         self._restore_staged = False
 
     def _on_settings_saved(self, settings: dict):

--- a/BIN/_app/launcher.py
+++ b/BIN/_app/launcher.py
@@ -1081,13 +1081,14 @@ class ACILauncher(QMainWindow):
                 gs_args,
                 cwd=str(GAMESERVER_DIR),
                 new_console=True,
+                elevate=True,
             )
             if not ok:
                 QMessageBox.warning(self, "Gameserver", "Could not start the game server.")
 
         if rpcn_mode == "self_hosted" and not self._rpcn_proc.is_running():
             QTimer.singleShot(2000, lambda: self._rpcn_proc.launch(
-                str(RPCN_EXE), [], cwd=str(RPCN_DATA_DIR), new_console=True,
+                str(RPCN_EXE), [], cwd=str(RPCN_DATA_DIR), new_console=True, elevate=True,
             ))
 
         if not self._rpcs3_proc.is_running():

--- a/BIN/_app/modules/config.py
+++ b/BIN/_app/modules/config.py
@@ -6,31 +6,34 @@ import subprocess
 import time
 
 
-def deploy_patches(rpcs3_dir: str, patches_dir: str):
-    patches_dest = os.path.join(rpcs3_dir, "portable", "patches")
-    config_dest  = os.path.join(rpcs3_dir, "portable", "config")
+def deploy_patches(
+    rpcs3_data_dir: str,
+    rpcs3_config_dir: str,
+    patches_dir: str
+):
+    patches_dest = os.path.join(rpcs3_data_dir, "patches")
     os.makedirs(patches_dest, exist_ok=True)
-    os.makedirs(config_dest,  exist_ok=True)
+    os.makedirs(rpcs3_config_dir, exist_ok=True)
     shutil.copy2(
         os.path.join(patches_dir, "imported_patch.yml"),
         os.path.join(patches_dest, "imported_patch.yml"),
     )
     shutil.copy2(
         os.path.join(patches_dir, "patch_config.yml"),
-        os.path.join(config_dest, "patch_config.yml"),
+        os.path.join(rpcs3_config_dir, "patch_config.yml"),
     )
 
 
 _GUI_PRESERVE = {"CurrentSettings.ini", "persistent_settings.dat"}
 
 
-def install_gui_assets(rpcs3_dir: str, patches_dir: str):
+def install_gui_assets(rpcs3_data_dir: str, patches_dir: str):
     """Deploy GuiConfigs themes and Icons/ui assets; never overwrite user settings files."""
     mappings = [
         (os.path.join(patches_dir, "GuiConfigs"),
-         os.path.join(rpcs3_dir, "portable", "GuiConfigs")),
+         os.path.join(rpcs3_data_dir, "GuiConfigs")),
         (os.path.join(patches_dir, "Icons", "ui"),
-         os.path.join(rpcs3_dir, "portable", "Icons", "ui")),
+         os.path.join(rpcs3_data_dir, "Icons", "ui")),
     ]
     for src, dst in mappings:
         if not os.path.exists(src):
@@ -47,6 +50,7 @@ def install_gui_assets(rpcs3_dir: str, patches_dir: str):
 
 def ensure_custom_config(
     rpcs3_dir: str,
+    rpcs3_config_dir: str,
     rpcs3_exe: str,
     timeout: int = 30,
     progress_cb=None,
@@ -56,9 +60,9 @@ def ensure_custom_config(
     Launches RPCS3 briefly to generate config.yml on first run.
     Returns True on success, False if config.yml never appeared.
     """
-    cfg_dir    = os.path.join(rpcs3_dir, "portable", "config", "custom_configs")
+    cfg_dir    = os.path.join(rpcs3_config_dir, "custom_configs")
     cfg_path   = os.path.join(cfg_dir, "config_NPUB31347.yml")
-    global_cfg = os.path.join(rpcs3_dir, "portable", "config", "config.yml")
+    global_cfg = os.path.join(rpcs3_config_dir, "config.yml")
     os.makedirs(cfg_dir, exist_ok=True)
 
     if os.path.exists(cfg_path):
@@ -82,7 +86,7 @@ def ensure_custom_config(
             return False
         if progress_cb:
             progress_cb("Config generated.")
-
+    os.path.join(global_cfg, cfg_path)
     shutil.copy2(global_cfg, cfg_path)
     return True
 

--- a/BIN/_app/modules/ip_detect.py
+++ b/BIN/_app/modules/ip_detect.py
@@ -1,24 +1,12 @@
-"""LAN IP detection via PowerShell default-route interface."""
-import subprocess
-
+import socket
 
 def get_lan_ip() -> str:
     """Return the LAN IPv4 address of the default-route NIC, or 127.0.0.1 on failure."""
-    ps = (
-        "$idx=(Get-NetRoute -DestinationPrefix '0.0.0.0/0' | "
-        "Sort-Object RouteMetric | Select-Object -First 1).InterfaceIndex; "
-        "(Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4).IPAddress"
-    )
     try:
-        result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", ps],
-            capture_output=True, text=True, timeout=10,
-        )
-        ip = result.stdout.strip()
-        # Validate: must be dotted-decimal IPv4
-        parts = ip.split(".")
-        if len(parts) == 4 and all(p.isdigit() and 0 <= int(p) <= 255 for p in parts):
-            return ip
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            # does not need to be reachable
+            # 192.0.2.0 = TEST-NET-1-0, can never be reachable.
+            s.connect(("192.0.2.0", 1)) 
+            return s.getsockname()[0]
     except Exception:
-        pass
-    return "127.0.0.1"
+        return "127.0.0.1"

--- a/BIN/_app/modules/processes.py
+++ b/BIN/_app/modules/processes.py
@@ -8,9 +8,11 @@ Supports two launch modes:
 import socket
 import subprocess
 import sys
+import platform
 
 from PySide6.QtCore import QObject, QProcess, QTimer, Signal
 
+PLATFORM = platform.system()
 
 def is_port_open(host: str = "127.0.0.1", port: int = 80, timeout: float = 0.4) -> bool:
     """Return True if a TCP connection to host:port succeeds within timeout seconds."""
@@ -40,12 +42,19 @@ class ManagedProcess(QObject):
         args: list[str],
         cwd: str | None = None,
         new_console: bool = False,
+        elevate: bool = False,
     ) -> bool:
         """Start the process.  Returns False if already running or failed to start."""
         if self.is_running():
             return False
 
-        if new_console and sys.platform == "win32":
+        if elevate and PLATFORM == 'Linux':
+            # darwin is cursed, windows can use powershell but is similarly cursed.
+            # you (should not) run Qt6 as root and is impossible under wayland.
+            args = [program] + args
+            program = "pkexec"
+
+        if new_console and PLATFORM == 'Windows':
             try:
                 self._popen = subprocess.Popen(
                     [program] + args,

--- a/BIN/play.sh
+++ b/BIN/play.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd $(dirname "$0")
+
+/usr/bin/env python3 _app/launcher.py


### PR DESCRIPTION
TSS utility scripts are not translated because they're too dank, but everything else is.

Linux / Darwin will need to build RPCS3 and RPCN with the patches, added convenience env vars to redirect portable installations.

Also `BIN/_app/modules/ip_detect.py` does not need to run powershell.