### PR TITLE
Add Apple Silicon macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /*.exe
 /*.7z
 /*.tar.xz
+/*.tar.xz.sha256
+/*.dmg
+.DS_Store
 
 # -------------------------------------------------------
 # TSS files -- licensed, not distributed (dir tracked via .gitkeep)
@@ -73,5 +76,13 @@ __pycache__/
 /BIN/_app/RPCS3/qt6/
 /BIN/_app/RPCS3/test/
 /BIN/_app/RPCS3/*.AppImage
+/BIN/_app/RPCS3/*.app/
 /BIN/_app/rpcn/rpcn.exe
 /BIN/_app/rpcn/rpcn
+
+# -------------------------------------------------------
+# Local macOS build and packaging workspaces
+# -------------------------------------------------------
+/.deps/
+/build-macos/
+/.macos-stage/

--- a/BIN/Play OPERATION ETERNAL LIBERATION (macOS).command
+++ b/BIN/Play OPERATION ETERNAL LIBERATION (macOS).command
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+APP="$ROOT/_app"
+PYTHON="$APP/python/bin/python3"
+GAMESERVER_PYTHON="$APP/python/bin/python3-gameserver"
+MOLTENVK_ICD="$APP/RPCS3/RPCS3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
+
+if [ "$(uname -m)" != "arm64" ]; then
+    echo "ERROR: This OEL package requires an Apple Silicon Mac." >&2
+    exit 1
+fi
+
+if [ ! -x "$PYTHON" ]; then
+    bash "$APP/setup.sh"
+fi
+
+if [ ! -x "$GAMESERVER_PYTHON" ]; then
+    cp -L "$PYTHON" "$GAMESERVER_PYTHON"
+fi
+
+if [ -f "$MOLTENVK_ICD" ]; then
+    export VK_ICD_FILENAMES="$MOLTENVK_ICD"
+fi
+export PYTHONNOUSERSITE=1
+
+# Generate local TLS files before the privileged server starts so they remain
+# owned and writable by the current user.
+if [ ! -f "$APP/gameserver/cert.pem" ] || [ ! -f "$APP/gameserver/key.pem" ]; then
+    (
+        cd "$APP/gameserver"
+        "$PYTHON" -c "import opeternal_listener as server; server.ensure_cert()"
+    )
+fi
+
+cd "$ROOT"
+exec "$PYTHON" "$APP/launcher.py" "$@"

--- a/BIN/READ_ME_FIRST.md
+++ b/BIN/READ_ME_FIRST.md
@@ -12,6 +12,13 @@ On Linux (x86_64, distros from roughly 2022 onward - RPCS3 needs glibc 2.35), ru
 ./Play\ OPERATION\ ETERNAL\ LIBERATION\ \(Linux\).sh
 ```
 
+On Apple Silicon macOS 14.4 or newer, open
+**OPERATION ETERNAL LIBERATION.app**, or run:
+
+```bash
+./Play\ OPERATION\ ETERNAL\ LIBERATION\ \(macOS\).command
+```
+
 The game server uses ports 80 and 443, so on first launch you are asked for
 your password to allow that.
 
@@ -48,9 +55,9 @@ The **Saves** tab has three things:
 
 ## Updates
 
-On Windows, run the newer installer over the existing install. On Linux,
-extract the newer tarball over the existing folder. Either way your RPCS3
-portable data, launcher settings, and `TSS` folder are preserved.
+On Windows, run the newer installer over the existing install. On Linux or
+macOS, extract the newer tarball over the existing folder. Either way your
+RPCS3 portable data, launcher settings, and `TSS` folder are preserved.
 
 ## Troubleshooting
 
@@ -73,6 +80,14 @@ portable data, launcher settings, and `TSS` folder are preserved.
   ```
 
 - **Where the logs are (Linux).** RPCS3: `~/.cache/rpcs3/RPCS3.log`. Game server: `_app/gameserver/gameserver.log`.
+- **Game server fails on macOS.** Approve the native administrator prompt and
+  check `/tmp/oel-gameserver-<uid>.log`. The elevated server exits
+  automatically when the launcher closes.
+- **Campaign cutscene is black on macOS.** Use the `RPCS3.app` included in the
+  OEL package. Older or unrelated builds can stall in CRI Mana video decoding.
+- **Where the logs are (macOS).** RPCS3:
+  `~/Library/Caches/rpcs3/RPCS3.log`. Game server:
+  `_app/gameserver/gameserver.log`.
 
 ## Hosting your own server
 

--- a/BIN/_app/app/paths.py
+++ b/BIN/_app/app/paths.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 _IS_WIN     = sys.platform == "win32"
+_IS_MAC     = sys.platform == "darwin"
 _EXE        = ".exe" if _IS_WIN else ""
 
 APP_DIR     = Path(__file__).resolve().parent.parent   # _app/
@@ -29,6 +30,8 @@ PYTHON_EXE  = APP_DIR / "python" / "python.exe" if _IS_WIN else APP_DIR / "pytho
 def _resolve_rpcs3_exe() -> Path:
     if _IS_WIN:
         return RPCS3_DIR / "rpcs3.exe"
+    if _IS_MAC:
+        return RPCS3_DIR / "RPCS3.app" / "Contents" / "MacOS" / "rpcs3"
     images = sorted(RPCS3_DIR.glob("*.AppImage"))
     if images:
         return images[0]
@@ -82,10 +85,11 @@ def rpcs3_launch_args() -> list:
 
 
 def rpcs3_log_path() -> Path:
-    """RPCS3.log location. fs::get_log_dir is the config dir on Windows but the
-    cache dir on Linux, which ignores portable mode."""
+    """Return RPCS3's platform-specific log path."""
     if _IS_WIN:
         return PORTABLE_DIR / "log" / "RPCS3.log"
+    if _IS_MAC:
+        return Path.home() / "Library" / "Caches" / "rpcs3" / "RPCS3.log"
     cache = os.environ.get("XDG_CACHE_HOME") or os.path.join(os.environ.get("HOME", "."), ".cache")
     return Path(cache) / "rpcs3" / "RPCS3.log"
 
@@ -103,6 +107,8 @@ def gameserver_python() -> Path:
 
 def privileged_port_command() -> str:
     """The shell command that lets the game server bind ports 80 and 443."""
+    if _IS_MAC:
+        return "Launch OEL normally and approve the macOS administrator prompt."
     py = gameserver_python()
     if py.name == "python3-gameserver":
         return f"sudo setcap cap_net_bind_service=+ep '{py}'"
@@ -110,7 +116,12 @@ def privileged_port_command() -> str:
 
 
 def privileged_port_help() -> str:
-    """Explanation for the Linux <1024 port restriction (ports 80/443)."""
+    """Explain the platform's restriction on ports 80 and 443."""
+    if _IS_MAC:
+        return (
+            "The game server must listen on ports 80 and 443. macOS will show "
+            "an administrator prompt when the server starts."
+        )
     msg = ("The game server must listen on ports 80 and 443, which Linux "
            "reserves for privileged processes.\n\n"
            "Run this once in a terminal, then launch again:\n\n"

--- a/BIN/_app/app/window.py
+++ b/BIN/_app/app/window.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import (
     QMainWindow, QWidget, QTabWidget, QVBoxLayout, QMessageBox,
 )
 
-from app.paths import _IS_WIN, ROOT_DIR, VERSION
+from app.paths import _IS_WIN, _IS_MAC, ROOT_DIR, VERSION
 from app.settings import load_settings, save_settings
 from views.play_tab import PlayTab
 from views.saves_tab import SavesTab
@@ -44,7 +44,8 @@ class ACILauncher(QMainWindow):
         if self._settings.get("auto_check_updates"):
             QTimer.singleShot(1500, self._controller.check_for_updates_startup)
 
-        if not _IS_WIN and not self._settings.get("desktop_shortcut_offered"):
+        if (not _IS_WIN and not _IS_MAC
+                and not self._settings.get("desktop_shortcut_offered")):
             QTimer.singleShot(1200, self._offer_desktop_shortcut)
 
     def _build_ui(self):

--- a/BIN/_app/gameserver/opeternal_listener.py
+++ b/BIN/_app/gameserver/opeternal_listener.py
@@ -515,6 +515,12 @@ def main():
                         help="Remote port to forward HTTP (:80) traffic to. Default 80.")
     parser.add_argument("--forward-https-port", type=int, default=443,
                         help="Remote port to forward HTTPS (:443) traffic to. Default 443.")
+    parser.add_argument(
+        "--watch-pid",
+        type=int,
+        default=None,
+        help="Exit when this process ID is no longer running.",
+    )
     args = parser.parse_args()
 
     _rotate_log()
@@ -559,9 +565,18 @@ def main():
 
     try:
         while True:
+            if args.watch_pid is not None:
+                try:
+                    os.kill(args.watch_pid, 0)
+                except ProcessLookupError:
+                    log(f"watched process {args.watch_pid} exited; shutting down")
+                    break
+                except PermissionError:
+                    pass
             time.sleep(1)
     except KeyboardInterrupt:
         log("shutting down")
+    finally:
         _close_log_on_exit()
 
 

--- a/BIN/_app/modules/config.py
+++ b/BIN/_app/modules/config.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 
 from . import games
@@ -111,6 +112,34 @@ def patch_game_config(cfg_path: str, lan_ip: str, bind_address: str = "", upnp: 
     content = re.sub(r"Bind address:.*",
                      f"Bind address: {bind_address or '0.0.0.0'}", content)
     content = re.sub(r"Frame limit:.*", "Frame limit: 30", content)
+    if sys.platform == "darwin":
+        content = re.sub(
+            r"^(\s*)Accurate RSX reservation access:.*$",
+            r"\1Accurate RSX reservation access: true",
+            content,
+            flags=re.MULTILINE,
+        )
+        content = re.sub(
+            r"^(\s*)Driver Wake-Up Delay:.*$",
+            r"\1Driver Wake-Up Delay: 200",
+            content,
+            flags=re.MULTILINE,
+        )
+        if re.search(r"^\s+sceNp:", content, flags=re.MULTILINE):
+            content = re.sub(
+                r"^(\s+)sceNp:.*$",
+                r"\1sceNp: Error",
+                content,
+                flags=re.MULTILINE,
+            )
+        else:
+            content = re.sub(
+                r"^Log:\s*$",
+                "Log:\n  sceNp: Error",
+                content,
+                count=1,
+                flags=re.MULTILINE,
+            )
 
     with open(cfg_path, "w", encoding="utf-8") as f:
         f.write(content)

--- a/BIN/_app/modules/processes.py
+++ b/BIN/_app/modules/processes.py
@@ -8,11 +8,13 @@ Supports two launch modes:
     fallback when none is installed).  State is polled every 2 s via QTimer.
 """
 import os
+import shlex
 import shutil
 import signal
 import socket
 import subprocess
 import sys
+import uuid
 
 from PySide6.QtCore import QObject, QProcess, QTimer, Signal
 
@@ -125,6 +127,70 @@ def grant_port_capability(python_exe: str) -> str:
     # pkexec reports a dismissed prompt as 126; systemd-run gives no
     # distinct code, so a cancel there surfaces as "failed".
     return "cancelled" if res.returncode == 126 else "failed"
+
+
+def launch_macos_privileged(
+    program: str,
+    args: list[str],
+    cwd: str,
+    watch_pid: int,
+) -> bool:
+    """Start the game server through the native macOS administrator prompt.
+
+    The child redirects its inherited descriptors so ``osascript`` can return
+    immediately. ``--watch-pid`` makes the elevated server stop when the
+    launcher process exits.
+    """
+    if sys.platform != "darwin":
+        return False
+
+    del cwd  # launchctl starts the script by absolute path.
+    log_path = f"/tmp/oel-gameserver-{os.getuid()}.log"
+    label = f"community.operations-team.oel.gameserver.{watch_pid}.{uuid.uuid4().hex[:8]}"
+    argv = [program, *args, "--watch-pid", str(watch_pid)]
+    launch_argv = [
+        "/bin/launchctl", "submit",
+        "-l", label,
+        "-o", log_path,
+        "-e", log_path,
+        "--", *argv,
+    ]
+    command = " ".join(shlex.quote(item) for item in launch_argv)
+    try:
+        result = subprocess.run(
+            [
+                "/usr/bin/osascript",
+                "-e", "on run argv",
+                "-e", "do shell script (item 1 of argv) with administrator privileges",
+                "-e", "end run",
+                "--", command,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def ensure_gameserver_certificate(python_exe: str, cwd: str) -> bool:
+    """Generate the local TLS files as the current, non-privileged user."""
+    try:
+        result = subprocess.run(
+            [
+                python_exe,
+                "-c",
+                "import opeternal_listener as server; server.ensure_cert()",
+            ],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
 
 
 class ManagedProcess(QObject):

--- a/BIN/_app/viewmodels/launch_controller.py
+++ b/BIN/_app/viewmodels/launch_controller.py
@@ -3,6 +3,8 @@
 Keeps a window reference to parent its modal dialogs and read the tabs, because
 the launch flow is a chain of synchronous modal dialogs.
 """
+import os
+import time
 import uuid
 from pathlib import Path
 
@@ -11,7 +13,7 @@ from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 from app.paths import (
-    _IS_WIN, APP_DIR, RPCS3_DIR, RPCN_DIR, GAMESERVER_DIR,
+    _IS_WIN, _IS_MAC, APP_DIR, RPCS3_DIR, RPCN_DIR, GAMESERVER_DIR,
     RPCS3_EXE, RPCN_EXE, GAMESERVER_SCRIPT, GAMESERVER_LOG,
     PORTABLE_DIR, RPCN_YML, GAME_USRDIR,
     VERSION, RELEASE_CHANNEL, GITHUB_REPO,
@@ -233,19 +235,45 @@ class LaunchController(QObject):
 
         if not processes.is_port_open(swap_ip):
             gs_python = gameserver_python()
-            if (not _IS_WIN
-                    and processes.needs_port_privilege(str(gs_python), swap_ip)
-                    and not self._grant_port_privilege(gs_python, swap_ip)):
+            if _IS_MAC:
+                ok = processes.ensure_gameserver_certificate(
+                    str(gs_python), str(GAMESERVER_DIR)
+                )
+                if ok:
+                    ok = processes.launch_macos_privileged(
+                        str(gs_python), gs_args, str(GAMESERVER_DIR), os.getpid()
+                    )
+                if ok:
+                    for _ in range(50):
+                        if processes.is_port_open(swap_ip):
+                            break
+                        time.sleep(0.1)
+                    ok = processes.is_port_open(swap_ip)
+                    if ok:
+                        self._win._play_tab.set_process_status("gameserver", True)
+            else:
+                if (not _IS_WIN
+                        and processes.needs_port_privilege(str(gs_python), swap_ip)
+                        and not self._grant_port_privilege(gs_python, swap_ip)):
+                    self._win._play_tab.set_launch_enabled(True)
+                    return
+                ok = self._gameserver.launch(
+                    str(gs_python),
+                    gs_args,
+                    cwd=str(GAMESERVER_DIR),
+                    new_console=True,
+                )
+            if not ok:
+                detail = (
+                    f"\n\nSee /tmp/oel-gameserver-{os.getuid()}.log for details."
+                    if _IS_MAC else ""
+                )
+                QMessageBox.warning(
+                    self._win, "Gameserver",
+                    "Could not start the game server." + detail,
+                )
                 self._win._play_tab.set_launch_enabled(True)
                 return
-            ok = self._gameserver.launch(
-                str(gs_python),
-                gs_args,
-                cwd=str(GAMESERVER_DIR),
-                new_console=True,
-            )
-            if not ok:
-                QMessageBox.warning(self._win, "Gameserver", "Could not start the game server.")
 
         if rpcn_mode == "self_hosted" and not self._rpcn_proc.is_running():
             QTimer.singleShot(2000, lambda: self._rpcn_proc.launch(

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,10 +34,58 @@ cargo build --release
 cp target/release/rpcn ../../BIN/_app/rpcn/rpcn
 ```
 
+## macOS (Apple Silicon)
+
+The macOS client is built natively for arm64 and requires macOS 14.4 or newer,
+Xcode Command Line Tools, Homebrew, Rust, and approximately 80 GiB of free
+space for a clean source build:
+
+```bash
+xcode-select --install
+brew install cmake ninja ccache llvm@21 qt sdl3 opencv@4 \
+  molten-vk vulkan-headers vulkan-loader protobuf rust p7zip gcc
+```
+
+The local build helper reads the pinned commits and ordered OEL patch series,
+including the Apple Silicon RPCS3 revision tested with CRI Mana campaign
+playback, builds RPCS3 and RPCN, and stages both under `BIN/_app`:
+
+```bash
+./ci/build-macos.sh
+```
+
+It uses RPCS3's macOS deployment tooling to bundle Qt, MoltenVK, and non-system
+libraries into `RPCS3.app`; do not substitute an app from an existing user
+installation. Homebrew `protobuf` and `fmt` have conflicted with RPCS3's
+bundled dependencies in some configurations. The pinned upstream build flow
+temporarily unlinks conflicting formulae; the helper records and restores
+their previous Homebrew link state afterward.
+
+Provision the self-contained arm64 Python runtime and build the complete
+client archive:
+
+```bash
+./ci/provision-macos-python.sh
+./package-macos.sh
+```
+
+`package-macos.sh` verifies arm64 slices, app signatures, MoltenVK layout,
+symlink containment, and the absence of Homebrew/build-tree load paths before
+creating `OP-ETERNAL-{version}-macos-arm64.tar.xz`.
+
+The produced apps are ad-hoc signed. Developer ID signing and Apple
+notarization require maintainer-owned credentials and are outside the local
+build.
+
 ## Packaging
 
 **Windows**: `package.bat` requires [Inno Setup 6](https://jrsoftware.org/isdl.php) at `C:\Program Files (x86)\Inno Setup 6\ISCC.exe` and [7-Zip](https://www.7-zip.org/download.html) at `C:\Program Files\7-Zip\7z.exe`. Produces `OP-ETERNAL-Setup-{version}.exe`, `OEL-SRC-{version}.7z`, and `OEL-DOCKER-{version}.7z`.
 
 **Linux**: `package.sh` produces `OEL-SRC-{version}.tar.xz` and `OEL-DOCKER-{version}.tar.xz`, plus the client bundle `OP-ETERNAL-{version}-linux-x86_64.tar.xz` when an AppImage is staged in `BIN/_app/RPCS3` and `ci/provision-linux-python.sh` has provisioned the bundled Python.
+
+**macOS**: `package-macos.sh` produces
+`OP-ETERNAL-{version}-macos-arm64.tar.xz` and its SHA-256 file after
+`ci/build-macos.sh` has staged RPCS3/RPCN and
+`ci/provision-macos-python.sh` has staged Python.
 
 All versioned from `AppVersion` in `OEL.iss`. `OEL-DOCKER` is a source bundle for Linux self-hosters; they extract it, `cd BIN`, and run `docker compose up -d --build`.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -5,9 +5,9 @@ This repository contains original code authored by The -OPERATIONS- Team alongsi
 | Path | License | Notes |
 |---|---|---|
 | `BIN/_app/**` (launcher, gameserver, modules, patches, assets) | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. See [LICENSE](LICENSE). |
-| `BIN/Play OPERATION ETERNAL LIBERATION.bat` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
+| `BIN/Play OPERATION ETERNAL LIBERATION.*` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
 | `BIN/docker/**`, `BIN/docker-compose.yml` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
-| `OEL.iss`, `package.bat` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
+| `OEL.iss`, `package.bat`, `package.sh`, `package-macos.sh`, `packaging/**` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
 | `ci/**`, `WORK/**` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code. |
 | `SRC/clone-git-repos.*`, `SRC/apply-patches.*`, `SRC/reset-git-repos.*`, `SRC/pinned-commits.env`, `SRC/README.md`, `SRC/EXTERN_PATCHES.md` | AGPL-3.0-or-later, with RPCS3 compatibility exception | Original code and documentation. |
 | `SRC/PATCH/RPCS3/*.patch` | GPL-2.0-only | Derivative of RPCS3 sources. Matches the upstream RPCS3 license. |

--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@ cd OPERATION-ETERNAL-LIBERATION
 
 The game server uses ports 80 and 443, so on first launch you are asked for your password to allow that.
 
-### macOS (Apple Silicon)
+### macOS quick start (Apple Silicon)
 
-Download `OP-ETERNAL-*-macos-arm64.tar.xz`, extract it, and open
-**OPERATION ETERNAL LIBERATION.app**. You can also run the command entry point:
+> Requires an Apple Silicon Mac (M1 or newer) running macOS 14.4 or newer.
+> Intel Macs are not supported.
+
+1. Download `OP-ETERNAL-*-macos-arm64.tar.xz` from the
+   [releases page](https://github.com/The-OPERATIONS-Team/OPERATION-ETERNAL-LIBERATION/releases)
+   and extract it.
+2. Open **OPERATION ETERNAL LIBERATION.app**. If Gatekeeper blocks the first
+   launch, right-click the app and choose **Open** once.
+3. Approve the macOS administrator prompt. The local game server needs ports
+   80 and 443.
+4. In the bundled RPCS3, install your PS3 firmware and game version 2.11, then
+   place all 15 TSS files in the package's `TSS` folder.
+5. Sign in to RPCN and start the game through the OEL app. Use the OEL app for
+   every later launch so its patches and network configuration are applied.
+
+Terminal users can start the same launcher with:
 
 ```bash
 tar -xJf OP-ETERNAL-*-macos-arm64.tar.xz
@@ -37,10 +51,7 @@ cd OPERATION-ETERNAL-LIBERATION
 "./Play OPERATION ETERNAL LIBERATION (macOS).command"
 ```
 
-The first game launch displays the normal macOS administrator prompt because
-the local game server must bind ports 80 and 443. The distributed application
-is ad-hoc signed rather than notarized; if Gatekeeper quarantines the extracted
-folder, right-click the app and choose **Open** once.
+The application is ad-hoc signed rather than notarized.
 
 ### All platforms
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,23 @@ cd OPERATION-ETERNAL-LIBERATION
 
 The game server uses ports 80 and 443, so on first launch you are asked for your password to allow that.
 
-### Both platforms
+### macOS (Apple Silicon)
+
+Download `OP-ETERNAL-*-macos-arm64.tar.xz`, extract it, and open
+**OPERATION ETERNAL LIBERATION.app**. You can also run the command entry point:
+
+```bash
+tar -xJf OP-ETERNAL-*-macos-arm64.tar.xz
+cd OPERATION-ETERNAL-LIBERATION
+"./Play OPERATION ETERNAL LIBERATION (macOS).command"
+```
+
+The first game launch displays the normal macOS administrator prompt because
+the local game server must bind ports 80 and 443. The distributed application
+is ad-hoc signed rather than notarized; if Gatekeeper quarantines the extracted
+folder, right-click the app and choose **Open** once.
+
+### All platforms
 
 You provide:
 
@@ -40,7 +56,9 @@ The **Saves** tab includes a save editor, a save backup browser, and a "new game
 
 ### Updating
 
-On Windows, run a newer installer over the existing install. On Linux, extract a newer tarball over the existing folder. Your RPCS3 portable data, RPCN config files, launcher settings, and `TSS` folder are preserved.
+On Windows, run a newer installer over the existing install. On Linux or
+macOS, extract a newer tarball over the existing folder. Your RPCS3 portable
+data, RPCN config files, launcher settings, and `TSS` folder are preserved.
 
 ### Troubleshooting
 
@@ -50,6 +68,14 @@ On Windows, run a newer installer over the existing install. On Linux, extract a
 - **Can't host or join rooms.** Right-click the game in RPCS3, open *Custom Configuration > Network*, enable **UPnP**.
 - **TSS warning on launch.** Drop your 15 TSS files into the `TSS` folder.
 - **"Game server ports" error (Linux).** Run the command shown in the dialog once, then launch again.
+- **The macOS administrator prompt does not appear.** Launch through the app
+  or the macOS `.command` file, not by running `launcher.py` from another
+  environment. Check `/tmp/oel-gameserver-<uid>.log` if the server fails.
+- **Campaign cutscene remains black on macOS.** Confirm the package contains
+  the OEL-patched `RPCS3.app`; an unrelated or older RPCS3 build may stall in
+  the CRI Mana decoder.
+- **macOS logs.** RPCS3 writes `~/Library/Caches/rpcs3/RPCS3.log`; the local
+  game server writes `_app/gameserver/gameserver.log`.
 
 ## Hosting your own server
 

--- a/SRC/README.md
+++ b/SRC/README.md
@@ -2,9 +2,12 @@
 
 Clone the two repos at the correct commits, then apply the patches.
 
-Windows commands below use the `.bat` scripts; on Linux use the `.sh` scripts the same way.
+Windows commands below use the `.bat` scripts; on Linux and macOS use the
+`.sh` scripts the same way.
 
-If you downloaded the source archive as `OEL-SRC-*.7z` (built on Windows) and are working on Linux, convert line endings and make the scripts executable first:
+If you downloaded the source archive as `OEL-SRC-*.7z` (built on Windows) and
+are working on Linux or macOS, convert line endings and make the scripts
+executable first:
 
 ```
 dos2unix *.sh pinned-commits.env
@@ -52,3 +55,18 @@ cd GIT/rpcn
 cargo build --release
 cp target/release/rpcn ../../BIN/_app/rpcn/rpcn
 ```
+
+### macOS (Apple Silicon)
+
+From the repository root, `ci/build-macos.sh` performs these clone and patch
+steps when needed, selects the Apple Silicon RPCS3 revision from
+`pinned-commits.env`, builds both pinned projects, deploys the self-contained
+`RPCS3.app`, and stages the arm64 RPCN executable:
+
+```bash
+./ci/build-macos.sh
+./ci/provision-macos-python.sh
+./package-macos.sh
+```
+
+See the root `BUILDING.md` for prerequisites and bundle verification details.

--- a/SRC/pinned-commits.env
+++ b/SRC/pinned-commits.env
@@ -3,8 +3,12 @@
 #   - SRC/clone-git-repos.bat (DIY builders, from the OEL-SRC archive)
 #   - ci/build-all.ps1        (build VM)
 # Keep the parent-tree submodule gitlinks (git submodule status) aligned to
-# these values when bumping.
+# the shared RPCS3_COMMIT and RPCN_COMMIT values. Platform-specific overrides
+# are selected only by their platform build helper.
 RPCS3_URL=https://github.com/RPCS3/rpcs3.git
 RPCS3_COMMIT=a7fc31f3212c55bf0b70b45875c52dfc94f6641a
+# Apple Silicon requires this newer tested revision for working CRI Mana
+# campaign playback. Other platform builds retain the shared baseline above.
+RPCS3_MACOS_COMMIT=884652109cfcceee0eb5b415dc6d4bf10d054faa
 RPCN_URL=https://github.com/RipleyTom/rpcn.git
 RPCN_COMMIT=74ff917bfdcb55181413718824d6a80c502f9e97

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Build and stage OEL's pinned, patched RPCS3 and RPCN for Apple Silicon.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/SRC"
+RPCS3_SRC="$SRC/GIT/rpcs3"
+RPCN_SRC="$SRC/GIT/rpcn"
+SERIES_MARKER="$SRC/GIT/.oel-patch-series.sha256"
+ARTIFACTS="$ROOT/build-macos/artifacts"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+    echo "ERROR: Apple Silicon macOS is required." >&2
+    exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "ERROR: missing required tool: brew" >&2
+    exit 1
+fi
+export PATH="$(brew --prefix protobuf)/bin:$HOME/.cargo/bin:$PATH"
+
+for tool in cmake ninja git cargo rustc protoc 7z curl; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "ERROR: missing required tool: $tool" >&2
+        exit 1
+    fi
+done
+
+# Current RPCS3 deployment uses wget for one fixed download. macOS ships curl,
+# so provide the small compatible surface locally instead of adding a package.
+COMPAT_BIN="$ROOT/build-macos/compat-bin"
+mkdir -p "$COMPAT_BIN"
+cat > "$COMPAT_BIN/wget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec /usr/bin/curl -fsSLO "$@"
+EOF
+chmod +x "$COMPAT_BIN/wget"
+
+# shellcheck disable=SC1091
+source "$SRC/pinned-commits.env"
+RPCS3_BUILD_COMMIT="${RPCS3_MACOS_COMMIT:-$RPCS3_COMMIT}"
+
+if [ ! -d "$RPCS3_SRC/.git" ] || [ ! -d "$RPCN_SRC/.git" ]; then
+    bash "$SRC/clone-git-repos.sh"
+fi
+
+if [ "$(git -C "$RPCS3_SRC" rev-parse HEAD)" != "$RPCS3_BUILD_COMMIT" ]; then
+    if [ -n "$(git -C "$RPCS3_SRC" status --short --untracked-files=no)" ]; then
+        echo "ERROR: RPCS3 source has tracked changes at the wrong revision." >&2
+        echo "Use a fresh clone before switching to the macOS pin." >&2
+        exit 1
+    fi
+    git -C "$RPCS3_SRC" checkout --detach "$RPCS3_BUILD_COMMIT"
+    git -C "$RPCS3_SRC" submodule update --init --recursive
+    rm -f "$SERIES_MARKER"
+fi
+if [ "$(git -C "$RPCS3_SRC" rev-parse HEAD)" != "$RPCS3_BUILD_COMMIT" ]; then
+    echo "ERROR: RPCS3 checkout is not at the macOS pinned commit." >&2
+    exit 1
+fi
+if [ "$(git -C "$RPCN_SRC" rev-parse HEAD)" != "$RPCN_COMMIT" ]; then
+    echo "ERROR: RPCN checkout is not at the pinned commit." >&2
+    exit 1
+fi
+
+SERIES_SHA="$(shasum -a 256 "$SRC/PATCH/series" "$SRC/PATCH/RPCS3/"*.patch \
+    "$SRC/PATCH/RPCN/"*.patch | shasum -a 256 | awk '{print $1}')"
+CURRENT_MARKER="$(cat "$SERIES_MARKER" 2>/dev/null || true)"
+if [ "$CURRENT_MARKER" != "$SERIES_SHA" ]; then
+    if [ -n "$(git -C "$RPCS3_SRC" status --short --untracked-files=no)" ] \
+            || [ -n "$(git -C "$RPCN_SRC" status --short --untracked-files=no)" ]; then
+        echo "ERROR: source trees contain unmarked tracked changes." >&2
+        echo "Use fresh pinned clones before applying the OEL patch series." >&2
+        exit 1
+    fi
+    bash "$SRC/apply-patches.sh"
+    printf '%s\n' "$SERIES_SHA" > "$SERIES_MARKER"
+fi
+
+BREW_PREFIX="$(brew --prefix)"
+LINKED_FORMULAE=()
+for formula in ffmpeg fmt protobuf; do
+    if [ -L "$BREW_PREFIX/var/homebrew/linked/$formula" ]; then
+        LINKED_FORMULAE+=("$formula")
+    fi
+    if brew list --versions "$formula" >/dev/null 2>&1; then
+        brew unlink "$formula" >/dev/null 2>&1 || true
+    fi
+done
+
+restore_brew_links() {
+    for formula in "${LINKED_FORMULAE[@]}"; do
+        brew link --overwrite "$formula" >/dev/null 2>&1 || true
+    done
+}
+trap restore_brew_links EXIT
+
+mkdir -p "$ARTIFACTS" "$ROOT/build-macos/ccache"
+if [ -f "$RPCS3_SRC/build/CMakeCache.txt" ] \
+        && ! grep -Fq "CMAKE_HOME_DIRECTORY:INTERNAL=$RPCS3_SRC" \
+            "$RPCS3_SRC/build/CMakeCache.txt"; then
+    echo "ERROR: existing RPCS3 build directory belongs to another source tree." >&2
+    exit 1
+fi
+
+QT_VER="6.11.1"
+QT_PREFIX="$(brew --prefix qt)"
+LLVM_PREFIX="$(brew --prefix llvm@21)"
+SDL_PREFIX="$(brew --prefix sdl3)"
+OPENCV_PREFIX="$(brew --prefix opencv@4)"
+VULKAN_SDK="$ROOT/build-macos/VulkanSDK"
+mkdir -p "$VULKAN_SDK/lib"
+ln -sfn "$(brew --prefix vulkan-headers)/include" "$VULKAN_SDK/include"
+ln -sfn "$(brew --prefix vulkan-loader)/lib/libvulkan.dylib" \
+    "$VULKAN_SDK/lib/libvulkan.dylib"
+
+# deploy-mac.sh reads translations from the layout used by RPCS3 CI. Recreate
+# only that portion with Homebrew's matching qttranslations package.
+QT_CI_ROOT="$RPCS3_SRC/qt-downloader/$QT_VER/clang_64"
+rm -rf "$QT_CI_ROOT"
+mkdir -p "$QT_CI_ROOT"
+ln -s "$(brew --prefix qttranslations)/share/qt/translations" \
+    "$QT_CI_ROOT/translations"
+
+COMM_TAG="$(awk '/version{.*}/ { printf("%d.%d.%d", $5, $6, $7) }' \
+    "$RPCS3_SRC/rpcs3/rpcs3_version.cpp")"
+COMM_COUNT="$(git -C "$RPCS3_SRC" rev-list --count HEAD)"
+COMM_HASH="$(git -C "$RPCS3_SRC" rev-parse --short=8 HEAD)"
+LVER="${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}"
+
+PATH="$LLVM_PREFIX/bin:$PATH" \
+CC=clang \
+CXX=clang++ \
+Qt6_DIR="$QT_PREFIX/lib/cmake/Qt6" \
+SDL3_DIR="$SDL_PREFIX/lib/cmake/SDL3" \
+LLVM_DIR="$LLVM_PREFIX/lib/cmake/llvm" \
+OpenCV_DIR="$OPENCV_PREFIX/lib/cmake/opencv4" \
+VULKAN_SDK="$VULKAN_SDK" \
+CCACHE_DIR="$ROOT/build-macos/ccache" \
+LDFLAGS="-L$LLVM_PREFIX/lib/c++ -L$LLVM_PREFIX/lib/unwind -lunwind" \
+cmake \
+    -S "$RPCS3_SRC" \
+    -B "$RPCS3_SRC/build" \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_RPCS3_TESTS=OFF \
+    -DRUN_RPCS3_TESTS=OFF \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=14.4 \
+    -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)" \
+    -DMACOSX_BUNDLE_SHORT_VERSION_STRING="$COMM_TAG" \
+    -DMACOSX_BUNDLE_BUNDLE_VERSION="$COMM_COUNT" \
+    -DMACDEPLOYQT_EXECUTABLE="$QT_PREFIX/bin/macdeployqt" \
+    -DQt6_DIR="$QT_PREFIX/lib/cmake/Qt6" \
+    -DSDL3_DIR="$SDL_PREFIX/lib/cmake/SDL3" \
+    -DLLVM_DIR="$LLVM_PREFIX/lib/cmake/llvm" \
+    -DOpenCV_DIR="$OPENCV_PREFIX/lib/cmake/opencv4" \
+    -DSTATIC_LINK_LLVM=ON \
+    -DUSE_SDL=ON \
+    -DUSE_DISCORD_RPC=ON \
+    -DUSE_AUDIOUNIT=ON \
+    -DUSE_SYSTEM_FFMPEG=OFF \
+    -DUSE_SYSTEM_PROTOBUF=OFF \
+    -DUSE_NATIVE_INSTRUCTIONS=OFF \
+    -DUSE_PRECOMPILED_HEADERS=OFF \
+    -DUSE_SYSTEM_MVK=ON \
+    -DUSE_SYSTEM_SDL=ON \
+    -DUSE_SYSTEM_OPENCV=ON
+
+PATH="$LLVM_PREFIX/bin:$PATH" \
+CCACHE_DIR="$ROOT/build-macos/ccache" \
+LDFLAGS="-L$LLVM_PREFIX/lib/c++ -L$LLVM_PREFIX/lib/unwind -lunwind" \
+cmake --build "$RPCS3_SRC/build" --parallel 6
+
+# Reuse the pinned upstream deployment step for MoltenVK, load-path rewriting,
+# translation deployment, optimization, and ad-hoc signing.
+rm -rf "$RPCS3_SRC/build/bin/MoltenVK"
+(
+    cd "$RPCS3_SRC"
+    export BREW_PATH="$BREW_PREFIX"
+    export LLVM_COMPILER_VER="21"
+    export WORKDIR="$RPCS3_SRC"
+    export QT_VER
+    export LVER
+    export PATH="$COMPAT_BIN:$PATH"
+    export BUILD_ARTIFACTSTAGINGDIRECTORY="$ARTIFACTS"
+    export RELEASE_MESSAGE="$ROOT/build-macos/GitHubReleaseMessage.txt"
+    .ci/deploy-mac.sh
+)
+python3 "$ROOT/ci/fix-macos-load-paths.py" \
+    "$RPCS3_SRC/build/bin/RPCS3.app"
+codesign --force --deep --sign - "$RPCS3_SRC/build/bin/RPCS3.app"
+
+restore_brew_links
+trap - EXIT
+
+RPCS3_APP="$RPCS3_SRC/build/bin/RPCS3.app"
+if [ ! -d "$RPCS3_APP" ]; then
+    echo "ERROR: RPCS3 build did not produce $RPCS3_APP" >&2
+    exit 1
+fi
+mkdir -p "$ROOT/BIN/_app/RPCS3/portable"
+rm -rf "$ROOT/BIN/_app/RPCS3/RPCS3.app"
+ditto "$RPCS3_APP" "$ROOT/BIN/_app/RPCS3/RPCS3.app"
+for directory in GuiConfigs Icons; do
+    if [ -d "$RPCS3_SRC/bin/$directory" ]; then
+        ditto "$RPCS3_SRC/bin/$directory" \
+              "$ROOT/BIN/_app/RPCS3/portable/$directory"
+    fi
+done
+
+RPCN_TARGET="$ROOT/build-macos/rpcn-target"
+(
+    cd "$RPCN_SRC"
+    CARGO_TARGET_DIR="$RPCN_TARGET" cargo build --locked --release
+)
+mkdir -p "$ROOT/BIN/_app/rpcn"
+cp "$RPCN_TARGET/release/rpcn" "$ROOT/BIN/_app/rpcn/rpcn"
+chmod +x "$ROOT/BIN/_app/rpcn/rpcn"
+
+file "$ROOT/BIN/_app/RPCS3/RPCS3.app/Contents/MacOS/rpcs3" | grep -q "arm64"
+file "$ROOT/BIN/_app/rpcn/rpcn" | grep -q "arm64"
+codesign --verify --deep --strict --verbose=2 \
+    "$ROOT/BIN/_app/RPCS3/RPCS3.app"
+
+echo "Staged Apple Silicon RPCS3 and RPCN under BIN/_app."

--- a/ci/fix-macos-load-paths.py
+++ b/ci/fix-macos-load-paths.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Remove build-machine Homebrew paths from a deployed macOS app bundle."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+FORBIDDEN_PREFIXES = ("/opt/homebrew", "/usr/local")
+
+
+def output(*args: str) -> str:
+    return subprocess.run(
+        args, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def is_macho(path: Path) -> bool:
+    return "Mach-O" in output("/usr/bin/file", "-b", str(path))
+
+
+def dependencies(path: Path) -> list[str]:
+    lines = output("/usr/bin/otool", "-L", str(path)).splitlines()[1:]
+    return [line.strip().split(" (", 1)[0] for line in lines if line.strip()]
+
+
+def install_id(path: Path) -> str | None:
+    lines = output("/usr/bin/otool", "-D", str(path)).splitlines()
+    return lines[1].strip() if len(lines) > 1 else None
+
+
+def rpaths(path: Path) -> list[str]:
+    lines = output("/usr/bin/otool", "-l", str(path)).splitlines()
+    found: list[str] = []
+    for index, line in enumerate(lines):
+        if line.strip() != "cmd LC_RPATH":
+            continue
+        for candidate in lines[index + 1:index + 4]:
+            candidate = candidate.strip()
+            if candidate.startswith("path "):
+                found.append(candidate[5:].split(" (offset", 1)[0])
+                break
+    return found
+
+
+def bundled_reference(dependency: str, frameworks: Path) -> tuple[Path, str]:
+    dep_path = Path(dependency)
+    framework_index = next(
+        (
+            index for index, part in enumerate(dep_path.parts)
+            if part.endswith(".framework")
+        ),
+        None,
+    )
+    if framework_index is None:
+        relative = Path(dep_path.name)
+    else:
+        relative = Path(*dep_path.parts[framework_index:])
+    return frameworks / relative, f"@rpath/{relative.as_posix()}"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} RPCS3.app", file=sys.stderr)
+        return 2
+
+    app = Path(sys.argv[1]).resolve()
+    frameworks = app / "Contents" / "Frameworks"
+    changed = 0
+    for path in app.rglob("*"):
+        if not path.is_file() or path.is_symlink() or not is_macho(path):
+            continue
+
+        edits: list[str] = []
+        current_id = install_id(path)
+        if current_id and current_id.startswith(FORBIDDEN_PREFIXES):
+            bundled, replacement = bundled_reference(current_id, frameworks)
+            if not bundled.exists():
+                raise RuntimeError(
+                    f"cannot rewrite unbundled install name {current_id} in {path}"
+                )
+            edits.extend(["-id", replacement])
+
+        for dependency in dependencies(path):
+            if not dependency.startswith(FORBIDDEN_PREFIXES):
+                continue
+            if dependency == current_id:
+                continue
+            bundled, replacement = bundled_reference(dependency, frameworks)
+            if not bundled.exists():
+                raise RuntimeError(
+                    f"cannot rewrite unbundled dependency {dependency} in {path}"
+                )
+            edits.extend(["-change", dependency, replacement])
+
+        for entry in rpaths(path):
+            if entry.startswith(FORBIDDEN_PREFIXES):
+                edits.extend(["-delete_rpath", entry])
+
+        if edits:
+            subprocess.run(
+                ["/usr/bin/install_name_tool", *edits, str(path)],
+                check=True,
+            )
+            changed += 1
+
+    print(f"Rewrote build-machine load paths in {changed} Mach-O files.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ci/provision-macos-python.sh
+++ b/ci/provision-macos-python.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Provision a self-contained Apple Silicon Python runtime for the macOS client.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="${1:-$ROOT/BIN/_app/python}"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+    echo "ERROR: macOS arm64 is required." >&2
+    exit 1
+fi
+
+PBS_TAG="20260610"
+PBS_BUILD="cpython-3.12.13+${PBS_TAG}-aarch64-apple-darwin-install_only_stripped"
+PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/${PBS_BUILD}.tar.gz"
+PBS_SHA256="f0a7fa7decc75df2b1a789329a44f657c4a15c0a683f197ce46a5cb621bc6ef4"
+
+if [ -x "$TARGET/bin/python3" ]; then
+    echo "Bundled Python already present at $TARGET"
+else
+    echo "Downloading $PBS_BUILD..."
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+    curl -fsSL "$PBS_URL" -o "$TMP/python.tar.gz"
+    ACTUAL_SHA256="$(shasum -a 256 "$TMP/python.tar.gz" | awk '{print $1}')"
+    if [ "$ACTUAL_SHA256" != "$PBS_SHA256" ]; then
+        echo "ERROR: Python archive checksum mismatch." >&2
+        exit 1
+    fi
+
+    echo "Extracting to $TARGET..."
+    rm -rf "$TARGET"
+    mkdir -p "$(dirname "$TARGET")"
+    tar -xzf "$TMP/python.tar.gz" -C "$(dirname "$TARGET")"
+    if [ "$(basename "$TARGET")" != "python" ]; then
+        mv "$(dirname "$TARGET")/python" "$TARGET"
+    fi
+fi
+
+echo "Installing pinned launcher dependencies..."
+"$TARGET/bin/python3" -m pip install --quiet --upgrade \
+    "cryptography==45.0.7" \
+    "PySide6-Essentials==6.9.3"
+
+# The launcher does not use Qt SQL. Its optional ODBC driver carries a
+# non-portable /usr/local dependency in the upstream wheel.
+rm -rf "$TARGET/lib/python3.12/site-packages/PySide6/Qt/plugins/sqldrivers"
+
+# Keep a distinct executable for the elevated server process.
+cp -L "$TARGET/bin/python3" "$TARGET/bin/python3-gameserver"
+chmod +x "$TARGET/bin/python3-gameserver"
+
+"$TARGET/bin/python3" -c \
+    "import PySide6.QtCore, cryptography; print('Bundled Python OK:', __import__('sys').version.split()[0])"
+file "$TARGET/bin/python3" | grep -q "arm64"

--- a/ci/verify-macos-bundle.py
+++ b/ci/verify-macos-bundle.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Verify that a packaged OEL Apple Silicon client is self-contained."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+FORBIDDEN_RUNTIME_NAMES = {
+    "cert.pem",
+    "key.pem",
+    "rpcn.yml",
+    "settings.json",
+}
+
+
+def run(*args: str) -> str:
+    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+def fail(message: str) -> None:
+    raise RuntimeError(message)
+
+
+def verify_symlinks(root: Path) -> None:
+    resolved_root = root.resolve()
+    for path in root.rglob("*"):
+        if not path.is_symlink():
+            continue
+        try:
+            target = path.resolve(strict=True)
+        except FileNotFoundError:
+            fail(f"broken symlink: {path}")
+        if target != resolved_root and resolved_root not in target.parents:
+            fail(f"symlink escapes package: {path} -> {target}")
+
+
+def verify_private_data(root: Path) -> None:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        lower_parts = {part.lower() for part in path.parts}
+        if path.name in FORBIDDEN_RUNTIME_NAMES or path.suffix.lower() == ".tss":
+            fail(f"private runtime data included: {path}")
+        if "dev_flash" in lower_parts or "dev_hdd0" in lower_parts:
+            fail(f"firmware or game data included: {path}")
+
+
+def verify_macho(path: Path, forbidden_prefixes: list[str]) -> bool:
+    description = run("/usr/bin/file", "-b", str(path))
+    if "Mach-O" not in description:
+        return False
+
+    arches = run("/usr/bin/lipo", "-archs", str(path)).split()
+    if "arm64" not in arches:
+        fail(f"Mach-O lacks arm64 slice: {path} ({' '.join(arches)})")
+
+    metadata = run("/usr/bin/otool", "-L", str(path))
+    metadata += run("/usr/bin/otool", "-l", str(path))
+    forbidden = ["/opt/homebrew", "/usr/local", "/tmp/Qt", *forbidden_prefixes]
+    for prefix in forbidden:
+        if prefix and prefix in metadata:
+            fail(f"non-portable load path {prefix!r} in {path}")
+    return True
+
+
+def verify_moltenvk(rpcs3_app: Path) -> None:
+    manifests = list(rpcs3_app.rglob("MoltenVK_icd.json"))
+    if len(manifests) != 1:
+        fail(f"expected one MoltenVK manifest, found {len(manifests)}")
+    manifest = manifests[0]
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    library_path = data.get("ICD", {}).get("library_path")
+    if not library_path:
+        fail("MoltenVK manifest has no library_path")
+    library = (manifest.parent / library_path).resolve()
+    if not library.is_file():
+        fail(f"MoltenVK manifest target is missing: {library}")
+    dylibs = [p for p in rpcs3_app.rglob("libMoltenVK.dylib") if p.is_file()]
+    if len(dylibs) != 1:
+        fail(f"expected one bundled libMoltenVK.dylib, found {len(dylibs)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("client_root", type=Path)
+    parser.add_argument("--forbid-prefix", action="append", default=[])
+    args = parser.parse_args()
+
+    root = args.client_root.resolve()
+    rpcs3_app = root / "_app" / "RPCS3" / "RPCS3.app"
+    wrapper_app = root / "OPERATION ETERNAL LIBERATION.app"
+    if not rpcs3_app.is_dir():
+        fail(f"missing {rpcs3_app}")
+    if not wrapper_app.is_dir():
+        fail(f"missing {wrapper_app}")
+
+    verify_symlinks(root)
+    verify_private_data(root)
+
+    macho_count = 0
+    for path in root.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            macho_count += int(verify_macho(path, args.forbid_prefix))
+    if macho_count == 0:
+        fail("no Mach-O files found")
+
+    verify_moltenvk(rpcs3_app)
+    run("/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", str(rpcs3_app))
+    run("/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", str(wrapper_app))
+
+    print(f"macOS bundle verification passed ({macho_count} Mach-O files).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/package-macos.sh
+++ b/package-macos.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Build a complete Apple Silicon OEL client archive from staged binaries.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+VERSION="$(awk -F'"' '/^#define AppVersion/ {print $2; exit}' "$ROOT/OEL.iss")"
+RPCS3_APP="$ROOT/BIN/_app/RPCS3/RPCS3.app"
+RPCN_BIN="$ROOT/BIN/_app/rpcn/rpcn"
+PYTHON_DIR="$ROOT/BIN/_app/python"
+OUTPUT="$ROOT/OP-ETERNAL-$VERSION-macos-arm64.tar.xz"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+    echo "ERROR: package-macos.sh must run on Apple Silicon macOS." >&2
+    exit 1
+fi
+if [ ! -d "$RPCS3_APP" ]; then
+    echo "ERROR: stage the patched RPCS3.app at $RPCS3_APP first." >&2
+    exit 1
+fi
+if [ ! -x "$RPCN_BIN" ]; then
+    echo "ERROR: stage the arm64 RPCN executable at $RPCN_BIN first." >&2
+    exit 1
+fi
+if [ ! -x "$PYTHON_DIR/bin/python3" ]; then
+    bash "$ROOT/ci/provision-macos-python.sh" "$PYTHON_DIR"
+fi
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+CLIENT="$STAGE/OPERATION-ETERNAL-LIBERATION"
+
+mkdir -p \
+    "$CLIENT/TSS" \
+    "$CLIENT/_app/RPCS3/portable" \
+    "$CLIENT/_app/rpcn" \
+    "$CLIENT/_app/gameserver" \
+    "$CLIENT/_app/data"
+
+cp "$ROOT/BIN/Play OPERATION ETERNAL LIBERATION (macOS).command" "$CLIENT/"
+cp "$ROOT/BIN/READ_ME_FIRST.md" "$CLIENT/"
+ditto "$ROOT/packaging/macos/OPERATION ETERNAL LIBERATION.app" \
+      "$CLIENT/OPERATION ETERNAL LIBERATION.app"
+
+cp "$ROOT/BIN/_app/launcher.py" "$ROOT/BIN/_app/setup.sh" "$CLIENT/_app/"
+for directory in app assets modules patches tools viewmodels views workers; do
+    ditto "$ROOT/BIN/_app/$directory" "$CLIENT/_app/$directory"
+done
+cp "$ROOT/BIN/_app/data/game_manifest.json" "$CLIENT/_app/data/"
+
+cp "$ROOT/BIN/_app/gameserver/opeternal_listener.py" \
+   "$ROOT/BIN/_app/gameserver/gameserver.sh" \
+   "$CLIENT/_app/gameserver/"
+if [ -d "$ROOT/BIN/_app/gameserver/community" ]; then
+    ditto "$ROOT/BIN/_app/gameserver/community" "$CLIENT/_app/gameserver/community"
+fi
+
+ditto "$PYTHON_DIR" "$CLIENT/_app/python"
+ditto "$RPCS3_APP" "$CLIENT/_app/RPCS3/RPCS3.app"
+for directory in GuiConfigs Icons; do
+    if [ -d "$ROOT/BIN/_app/RPCS3/portable/$directory" ]; then
+        ditto "$ROOT/BIN/_app/RPCS3/portable/$directory" \
+              "$CLIENT/_app/RPCS3/portable/$directory"
+    fi
+done
+
+cp "$RPCN_BIN" \
+   "$ROOT/BIN/_app/rpcn/rpcn.cfg" \
+   "$ROOT/BIN/_app/rpcn/scoreboards.cfg" \
+   "$ROOT/BIN/_app/rpcn/server_redirs.cfg" \
+   "$ROOT/BIN/_app/rpcn/servers.cfg" \
+   "$CLIENT/_app/rpcn/"
+
+# Strip local interpreter and Finder artifacts from copied source directories.
+python3 - "$CLIENT" <<'PY'
+from pathlib import Path
+import shutil
+import sys
+
+root = Path(sys.argv[1])
+for path in root.rglob("__pycache__"):
+    if path.is_dir():
+        shutil.rmtree(path)
+for path in root.rglob(".DS_Store"):
+    path.unlink(missing_ok=True)
+PY
+
+chmod +x \
+    "$CLIENT/Play OPERATION ETERNAL LIBERATION (macOS).command" \
+    "$CLIENT/OPERATION ETERNAL LIBERATION.app/Contents/MacOS/oel-launcher" \
+    "$CLIENT/_app/setup.sh" \
+    "$CLIENT/_app/gameserver/gameserver.sh" \
+    "$CLIENT/_app/python/bin/python3" \
+    "$CLIENT/_app/python/bin/python3-gameserver" \
+    "$CLIENT/_app/rpcn/rpcn"
+
+WRAPPER_PLIST="$CLIENT/OPERATION ETERNAL LIBERATION.app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$WRAPPER_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$WRAPPER_PLIST"
+
+# Sign after every bundle mutation.
+python3 "$ROOT/ci/fix-macos-load-paths.py" "$CLIENT/_app/RPCS3/RPCS3.app"
+codesign --force --deep --sign - "$CLIENT/_app/RPCS3/RPCS3.app"
+codesign --force --deep --sign - "$CLIENT/OPERATION ETERNAL LIBERATION.app"
+
+VERIFY_ARGS=("$CLIENT" --forbid-prefix "$ROOT")
+if [ -n "${OEL_FORBIDDEN_PREFIX:-}" ]; then
+    VERIFY_ARGS+=(--forbid-prefix "$OEL_FORBIDDEN_PREFIX")
+fi
+python3 "$ROOT/ci/verify-macos-bundle.py" "${VERIFY_ARGS[@]}"
+
+rm -f "$OUTPUT" "$OUTPUT.sha256"
+COPYFILE_DISABLE=1 tar --no-xattrs -C "$STAGE" -cJf "$OUTPUT" \
+    "OPERATION-ETERNAL-LIBERATION"
+shasum -a 256 "$OUTPUT" > "$OUTPUT.sha256"
+
+echo "Created:"
+echo "  $OUTPUT"
+echo "  $OUTPUT.sha256"

--- a/packaging/macos/OPERATION ETERNAL LIBERATION.app/Contents/Info.plist
+++ b/packaging/macos/OPERATION ETERNAL LIBERATION.app/Contents/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>OPERATION ETERNAL LIBERATION</string>
+    <key>CFBundleExecutable</key>
+    <string>oel-launcher</string>
+    <key>CFBundleIdentifier</key>
+    <string>community.operations-team.oel</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>OPERATION ETERNAL LIBERATION</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.2.4</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.2.4</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.4</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos/OPERATION ETERNAL LIBERATION.app/Contents/MacOS/oel-launcher
+++ b/packaging/macos/OPERATION ETERNAL LIBERATION.app/Contents/MacOS/oel-launcher
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLIENT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+exec "$CLIENT_ROOT/Play OPERATION ETERNAL LIBERATION (macOS).command" "$@"

--- a/tests/test_macos_support.py
+++ b/tests/test_macos_support.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "BIN" / "_app"
+SERVER = APP / "gameserver" / "opeternal_listener.py"
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class MacOSPathTests(unittest.TestCase):
+    def test_darwin_paths(self):
+        code = (
+            "import sys;"
+            "sys.platform='darwin';"
+            f"sys.path.insert(0,{str(APP)!r});"
+            "from app import paths;"
+            "print(paths.RPCS3_EXE);"
+            "print(paths.rpcs3_log_path())"
+        )
+        output = subprocess.check_output(
+            [sys.executable, "-c", code],
+            text=True,
+        ).splitlines()
+        self.assertTrue(
+            output[0].endswith("RPCS3/RPCS3.app/Contents/MacOS/rpcs3"),
+            output[0],
+        )
+        self.assertTrue(
+            output[1].endswith("Library/Caches/rpcs3/RPCS3.log"),
+            output[1],
+        )
+
+
+class MacOSConfigTests(unittest.TestCase):
+    def test_darwin_gpu_and_log_defaults(self):
+        sys.path.insert(0, str(APP))
+        from modules import config
+
+        source = (
+            "Core:\n"
+            "  Accurate RSX reservation access: false\n"
+            "Log:\n"
+            "Video:\n"
+            "  Driver Wake-Up Delay: 1\n"
+            "Net:\n"
+            "  Internet enabled: Disconnected\n"
+            "  PSN status: Disconnected\n"
+            "  IP swap list: \"\"\n"
+            "  UPNP Enabled: false\n"
+            "  Bind address: 0.0.0.0\n"
+            "  Frame limit: Off\n"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "config.yml"
+            path.write_text(source, encoding="utf-8")
+            with mock.patch.object(config.sys, "platform", "darwin"):
+                config.patch_game_config(str(path), "192.0.2.4")
+            result = path.read_text(encoding="utf-8")
+
+        self.assertIn("Accurate RSX reservation access: true", result)
+        self.assertIn("Driver Wake-Up Delay: 200", result)
+        self.assertIn("Log:\n  sceNp: Error", result)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "macOS only")
+class MacOSPrivilegeTests(unittest.TestCase):
+    def test_privileged_server_uses_launchctl_job(self):
+        sys.path.insert(0, str(APP))
+        from modules import processes
+
+        with mock.patch.object(
+            processes.subprocess,
+            "run",
+            return_value=mock.Mock(returncode=0),
+        ) as run:
+            result = processes.launch_macos_privileged(
+                "/tmp/python3",
+                ["/tmp/server.py", "--bind-ip", "127.0.0.1"],
+                "/tmp",
+                1234,
+            )
+
+        self.assertTrue(result)
+        command = run.call_args.args[0][-1]
+        self.assertIn("/bin/launchctl submit", command)
+        self.assertIn("--watch-pid 1234", command)
+        self.assertNotIn("nohup", command)
+
+
+class GameServerLifecycleTests(unittest.TestCase):
+    def test_watch_pid_stops_server(self):
+        port = free_port()
+        watcher = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(0.5)"]
+        )
+        with tempfile.TemporaryDirectory() as log_dir:
+            env = os.environ.copy()
+            env["OEL_LOG_DIR"] = log_dir
+            server = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SERVER),
+                    "--bind-ip", "127.0.0.1",
+                    "--http-port", str(port),
+                    "--no-https",
+                    "--forward", "127.0.0.1",
+                    "--watch-pid", str(watcher.pid),
+                ],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    if server.poll() is not None:
+                        break
+                    try:
+                        with socket.create_connection(("127.0.0.1", port), 0.1):
+                            break
+                    except OSError:
+                        time.sleep(0.05)
+                watcher.wait(timeout=3)
+                server.wait(timeout=4)
+                self.assertEqual(server.returncode, 0)
+            finally:
+                if watcher.poll() is None:
+                    watcher.terminate()
+                    watcher.wait(timeout=2)
+                if server.poll() is None:
+                    server.terminate()
+                    server.wait(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add Darwin-aware launcher paths, a native app/command entry point, and a `launchctl`-managed administrator flow for the local game server on ports 80 and 443.
- Add reproducible local Apple Silicon builds and packaging for OEL-patched RPCS3, RPCN, and a self-contained Python runtime. The macOS RPCS3 pin uses the tested revision required for CRI Mana campaign playback.
- Verify arm64 architecture, bundle-contained load paths and symlinks, MoltenVK layout, private-data exclusions, and ad-hoc signatures before producing the archive.
- Document installation, updating, source builds, packaging, troubleshooting, and a concise macOS quick start.

## Limitations

- Apple Silicon and macOS 14.4 or newer only.
- The generated apps are ad-hoc signed, not Developer ID signed or notarized.
- This adds a reproducible local build/package flow; hosted CI and release automation remain follow-up work.
- Firmware, game/license data, RPCN credentials, saves, and TSS files are not distributed and must be supplied by each user.

## Test plan

- [x] Run all four macOS path, configuration, privilege, and server-lifecycle unit tests.
- [x] Run Python compile checks, `bash -n` on every added shell entry point, and `plutil -lint` on the app wrapper.
- [x] Build OEL-patched RPCS3 and RPCN from the pinned source revisions with `ci/build-macos.sh`.
- [x] Package the complete client with `package-macos.sh`; verify 387 Mach-O files, arm64 slices, signatures, MoltenVK, load paths, symlinks, and private runtime-data exclusions.
- [x] Verify the generated SHA-256 checksum and extract the archive into a new isolated directory with no dependency on the source tree or deployed OEL installation.
- [x] Seed only copies of licensed firmware, game/RAP, RPCN, controller, save, and TSS data into the isolated installation.
- [x] Launch the privileged local game server, confirm ports 80/443 and an HTTP authorization response, and confirm `--watch-pid` cleanup.
- [x] Boot firmware 4.91, load RPCN/TSS data, and reach the main menu.
- [x] Play a CRI Mana campaign cutscene and enter mission gameplay at the 30 FPS cap.
- [x] Confirm the aircraft tree remains responsive.
- [x] Restart the packaged client and confirm the same saved credits, fuel, tickets, and progression load successfully.

Made with [Cursor](https://cursor.com)